### PR TITLE
Downgrade student

### DIFF
--- a/iris/pom.xml
+++ b/iris/pom.xml
@@ -1,20 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
+	<groupId>org.opentestsystem.delivery</groupId>
 	<artifactId>iris</artifactId>
 	<packaging>war</packaging>
+	<version>5.0.1</version>
 	<name>iris</name>
 
 	<parent>
-		<groupId>org.opentestsystem.delivery</groupId>
-		<artifactId>student-parent</artifactId>
-		<version>3.0.2-SNAPSHOT</version>
+		<groupId>org.opentestsystem.shared</groupId>
+		<artifactId>shared-master</artifactId>
+		<version>3.0.3</version>
 	</parent>
-
-	<properties>
-		<shared-master.version>3.0.1</shared-master.version>
-		<tds-dll.version>3.0.0</tds-dll.version>
-	</properties>
 
 	<dependencies>
 		<dependency>
@@ -31,6 +28,12 @@
 
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
+			<artifactId>item-renderer</artifactId>
+			<version>3.0.10</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>item-renderer-web</artifactId>
 			<version>3.0.10</version>
 			<type>war</type>
@@ -39,13 +42,13 @@
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>spellcheck</artifactId>
-			<version>3.0.2-SNAPSHOT</version>
+			<version>3.0.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>student</artifactId>
-			<version>3.0.2-SNAPSHOT</version>
+			<version>2.1.1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.opentestsystem.shared</groupId>
@@ -67,66 +70,82 @@
 					<groupId>org.opentestsystem.shared</groupId>
 					<artifactId>sb11-shared-code</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.opentestsystem.delivery</groupId>
+					<artifactId>item-renderer</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.opentestsystem.delivery</groupId>
+					<artifactId>student.library</artifactId>
+				</exclusion>
 			</exclusions>
 			<type>war</type>
 		</dependency>
 
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
-			<artifactId>item-renderer</artifactId>
-			<version>3.0.10</version>
-		</dependency>
-		<dependency>
-			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>tds-itemselection-aironline</artifactId>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.shared</groupId>
 			<artifactId>shared-web</artifactId>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.shared</groupId>
 			<artifactId>shared-tr-api</artifactId>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.shared</groupId>
 			<artifactId>shared-logging</artifactId>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.shared</groupId>
 			<artifactId>shared-threading</artifactId>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.shared</groupId>
 			<artifactId>shared-test</artifactId>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>tds-dll-api</artifactId>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>tds-dll-mssql</artifactId>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>tds-dll-mysql</artifactId>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>tds-itemselection-common</artifactId>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>item-scoring-api</artifactId>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>item-scoring-engine</artifactId>
+			<version>3.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>testscoring</artifactId>
+			<version>3.0.0</version>
 		</dependency>
 
 		<dependency>
@@ -204,6 +223,8 @@
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.4</version>
 				<configuration>
+					<warSourceExcludes>WEB-INF/lib/item-renderer-0.0.1.jar</warSourceExcludes>
+					<packagingExcludes>WEB-INF/lib/item-renderer-0.0.1.jar</packagingExcludes>
 					<webResources>
 					</webResources>
 				</configuration>

--- a/iris/pom.xml
+++ b/iris/pom.xml
@@ -29,13 +29,13 @@
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>item-renderer</artifactId>
-			<version>3.0.10</version>
+			<version>2.3.11</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.opentestsystem.delivery</groupId>
 			<artifactId>item-renderer-web</artifactId>
-			<version>3.0.10</version>
+			<version>2.3.11</version>
 			<type>war</type>
 		</dependency>
 


### PR DESCRIPTION
Make Iris depend on Student 2.1.1 and the versions of item-renderer and item-renderer-web with our changes (2.3.11)